### PR TITLE
Patch v25.15

### DIFF
--- a/Site/LogMan.io/Release Notes/v25.15.md
+++ b/Site/LogMan.io/Release Notes/v25.15.md
@@ -2,6 +2,10 @@
 
 ## Patches
 
+### v25.15.08
+
+- lmio-elman - Skip Jizera stream lifecycle check when it's missing
+
 ### v25.15.07
 
 - ASAB service advertisement fix (asab-config, asab-library, asab-iris, asab-remote-control, asab-pyppeteer, seacat-auth, lmio-receiver)

--- a/Site/LogMan.io/Versions/v25.15.08.yaml
+++ b/Site/LogMan.io/Versions/v25.15.08.yaml
@@ -1,0 +1,30 @@
+---
+define:
+  type: rc/version
+  product: LogMan.io
+  version: v25.15.08
+  asab_maestro_library: v25.15.05
+
+versions:
+  library lmio-common-library: v25.15.08
+
+  lmio-collector: v25.11.03
+  lmio-collector-system: v25.11.03
+  lmio-receiver: v25.14.04
+  lmio-parsec: v25.14.09
+  lmio-depositor: v25.15.10
+
+  lmio-lookupbuilder: v25.03.05
+  lmio-ipaddrproc: v25.03.05
+
+  lmio-baseliner: v25.15.15
+  lmio-correlator: v25.15.29
+  lmio-correlator-builder: v25.15.29
+  lmio-alerts: v25.12.02
+  lmio-watcher: v25.15.06
+
+  lmio-categorix: v24.45.05
+  lmio-feeds: v25.15.02
+  lmio-integ: v24.40.01
+
+  lmio-elman: v25.11.05


### PR DESCRIPTION
lmio-elman: v25.11.05 - Skip Jizera stream lifecycle check when it's missing