### PR TITLE
Release LogMan.io: v25.28-beta7

### DIFF
--- a/Site/LogMan.io/Versions/v25.28-beta7.yaml
+++ b/Site/LogMan.io/Versions/v25.28-beta7.yaml
@@ -1,0 +1,30 @@
+---
+define:
+  type: rc/version
+  product: LogMan.io
+  version: v25.28-beta7
+  asab_maestro_library: v25.28-beta2
+
+versions:
+  library lmio-common-library: v25.28-beta6
+
+  lmio-elman: v25.21
+
+  lmio-collector: v25.11
+  lmio-collector-system: v25.11
+  lmio-categorix: v24.45.05
+  lmio-receiver: v25.25
+  lmio-parsec: v25.23.03
+  lmio-lookupbuilder: v25.03.06
+  lmio-ipaddrproc: v25.03.06
+  lmio-depositor: v25.20.02
+
+  lmio-baseliner: v25.20.08
+  lmio-correlator: v25.20.16
+  lmio-correlator-builder: v25.20.16
+  lmio-watcher: v25.20.02
+  lmio-feeds: v25.20.02
+  lmio-alerts: v25.25
+  lmio-integ: v25.25.01
+
+  lmio-franz: v25.23.01


### PR DESCRIPTION
**Updated:**

lmio-common-library: v25.28-beta6
lmio-feeds: v25.20.02
lmio-parsec: v25.23.03
lmio-depositor: v25.20.02
lmio-baseliner: v25.20.08
lmio-correlator: v25.20.16
lmio-correlator-builder: v25.20.16