### PR TITLE
LogMan.io: v25.28.07 & ASAB Maestro: v25.28.06

### DIFF
--- a/Site/ASAB Maestro/Versions/v25.28.06.yaml
+++ b/Site/ASAB Maestro/Versions/v25.28.06.yaml
@@ -1,0 +1,50 @@
+---
+define:
+  type: rc/version
+  product: ASAB Maestro
+  version: v25.28.06
+
+versions:
+  library asab-maestro-library: v25.28.02
+
+  asab-config: v25.12.06
+  asab-discovery: v25.15.03
+  asab-governator: v25.25
+  asab-iris: v25.28.03
+  asab-library: v25.28
+  asab-pyppeteer: v25.11.02
+  asab-remote-control: v25.25
+  bs-query: v25.24
+  seacat-auth: v25.13.01
+
+  webapp seacat-auth: v24.31
+
+  webapp lmio_webui: v25.15.08
+  webapp asab_config_webui: v25.15.08
+  webapp asab_library_webui: v25.15.08
+  webapp asab_maestro_webui: v25.15.08
+  webapp asab_tools_webui: v25.15.08
+  webapp bs_query_webui: v25.15.08
+  webapp lmio_analysis_webui: v25.15.08
+  webapp lmio_lookup_webui: v25.15.08
+  webapp lmio_observability_webui: v25.15.08
+  webapp lmio_alert_management_webui: v25.15.08
+  webapp lmio_parser_builder_webui: v25.15.08
+  webapp seacat_admin_webui: v25.15.08
+  webapp seacat_account_webui: v25.15.08
+  webapp lmio_logsources_webui: v25.15.08
+
+  acmesh: 3.0.7
+  burrow: v24.16
+  elasticsearch: '7.17.28'
+  grafana: '10.3.1'
+  influxdb: '2.7.11'
+  jupyter: lab-4.0.9
+  kafdrop: '4.1.0'
+  kafka: '7.9.0'
+  kibana: '7.17.28'
+  mongo: '7.0.1'
+  nginx: '1.25.2'
+  telegraf: '1.34.1'
+  zookeeper: '3.9'
+  zoonavigator: '1.1.2'

--- a/Site/LogMan.io/Versions/v25.28.07.yaml
+++ b/Site/LogMan.io/Versions/v25.28.07.yaml
@@ -1,0 +1,30 @@
+---
+define:
+  type: rc/version
+  product: LogMan.io
+  version: v25.28.07
+  asab_maestro_application: v25.28.06
+
+versions:
+  library lmio-common-library: v25.28.04
+
+  lmio-elman: v25.21.07
+
+  lmio-collector: v25.11.03
+  lmio-collector-system: v25.11.03
+  lmio-categorix: v24.45.05
+  lmio-receiver: v25.25
+  lmio-parsec: v25.23.06
+  lmio-lookupbuilder: v25.03.06
+  lmio-ipaddrproc: v25.03.09
+  lmio-depositor: v25.20.05
+
+  lmio-baseliner: v25.20.10
+  lmio-correlator: v25.20.17
+  lmio-correlator-builder: v25.20.17
+  lmio-watcher: v25.20.08
+  lmio-feeds: v25.20.07
+  lmio-alerts: v25.25.04
+  lmio-integ: v25.25.01
+
+  lmio-franz: v25.23.02


### PR DESCRIPTION
**asab maestro v25.28.06:**
- `asab-maestro-library`: `v25.28.02`
- `asab-iris`: `v25.28.03`
- `webui`: v25.15.08

**logman v25.28.07**
- `lmio-parsec`: `v25.23.06`
- `lmio-watcher`: `v25.20.08`
- `lmio-alerts`: `v25.25.04`